### PR TITLE
Tiny optimization in scanner.go

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1,96 +1,96 @@
 package robotstxt
 
 import (
-    "errors"
-    "io"
-    "strconv"
-    "strings"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
 )
 
 type Parser struct {
-    tokens []string
-    pos    int
-    agent  string
+	tokens []string
+	pos    int
+	agent  string
 }
 
 func NewParser(tokens []string) *Parser {
-    return &Parser{tokens: tokens}
+	return &Parser{tokens: tokens}
 }
 
 func (p *Parser) ParseAll() (result []Rule, err error) {
-    var r *Rule
-    err = nil
-    for {
-        r, err = p.ParseRule()
-        if r != nil {
-            result = append(result, *r)
-        }
-        if err == io.EOF {
-            err = nil
-            break
-        }
-    }
-    return result, err
+	var r *Rule
+	err = nil
+	for {
+		r, err = p.ParseRule()
+		if r != nil {
+			result = append(result, *r)
+		}
+		if err == io.EOF {
+			err = nil
+			break
+		}
+	}
+	return result, err
 }
 
 func (p *Parser) ParseRule() (r *Rule, err error) {
-    t1, ok1 := p.popToken()
-    if !ok1 {
-        // proper EOF
-        return nil, io.EOF
-    }
+	t1, ok1 := p.popToken()
+	if !ok1 {
+		// proper EOF
+		return nil, io.EOF
+	}
 
-    t2, ok2 := p.peekToken()
-    switch strings.ToLower(t1) {
-    case "\n":
-        // Don't consume t2 and continue parsing
-        return nil, nil
-    case "user-agent":
-        if !ok2 {
-            // TODO: report error
-            return nil, errors.New("Unexpected EOF at token #" + strconv.Itoa(p.pos) + " namely: \"" + t1 + "\"")
-        }
-        p.agent = t2
-        p.popToken()
-        // continue parsing
-        return nil, nil
-    case "disallow":
-        if p.agent == "" {
-            // TODO: report error
-            return nil, errors.New("Disallow before User-agent.")
-        }
-        p.popToken()
+	t2, ok2 := p.peekToken()
+	switch strings.ToLower(t1) {
+	case "\n":
+		// Don't consume t2 and continue parsing
+		return nil, nil
+	case "user-agent":
+		if !ok2 {
+			// TODO: report error
+			return nil, errors.New("Unexpected EOF at token #" + strconv.Itoa(p.pos) + " namely: \"" + t1 + "\"")
+		}
+		p.agent = t2
+		p.popToken()
+		// continue parsing
+		return nil, nil
+	case "disallow":
+		if p.agent == "" {
+			// TODO: report error
+			return nil, errors.New("Disallow before User-agent.")
+		}
+		p.popToken()
 
-        if t2 == "" {
-          return &Rule{Agent: p.agent, Uri: t2, Allow: true}, nil
-        } else {
-          return &Rule{Agent: p.agent, Uri: t2, Allow: false}, nil
-        }
+		if t2 == "" {
+			return &Rule{Agent: p.agent, Uri: t2, Allow: true}, nil
+		} else {
+			return &Rule{Agent: p.agent, Uri: t2, Allow: false}, nil
+		}
 
-    case "allow":
-        if p.agent == "" {
-            // TODO: report error
-            return nil, errors.New("Disallow before User-agent.")
-        }
-        p.popToken()
-        return &Rule{Agent: p.agent, Uri: t2, Allow: true}, nil
-    }
+	case "allow":
+		if p.agent == "" {
+			// TODO: report error
+			return nil, errors.New("Disallow before User-agent.")
+		}
+		p.popToken()
+		return &Rule{Agent: p.agent, Uri: t2, Allow: true}, nil
+	}
 
-    return nil, errors.New("Unknown token: " + strconv.Quote(t1))
+	return nil, errors.New("Unknown token: " + strconv.Quote(t1))
 }
 
 func (p *Parser) popToken() (tok string, ok bool) {
-    if p.pos >= len(p.tokens) {
-        return "", false
-    }
-    tok = p.tokens[p.pos]
-    p.pos++
-    return tok, true
+	if p.pos >= len(p.tokens) {
+		return "", false
+	}
+	tok = p.tokens[p.pos]
+	p.pos++
+	return tok, true
 }
 
 func (p *Parser) peekToken() (tok string, ok bool) {
-    if p.pos >= len(p.tokens) {
-        return "", false
-    }
-    return p.tokens[p.pos], true
+	if p.pos >= len(p.tokens) {
+		return "", false
+	}
+	return p.tokens[p.pos], true
 }

--- a/robotstxt.go
+++ b/robotstxt.go
@@ -4,122 +4,122 @@
 package robotstxt
 
 import (
-    "bytes"
-    "errors"
-    "strings"
+	"bytes"
+	"errors"
+	"strings"
 )
 
 type RobotsData struct {
-    DefaultAgent string
-    // private
-    rules       []Rule
-    allowAll    bool
-    disallowAll bool
+	DefaultAgent string
+	// private
+	rules       []Rule
+	allowAll    bool
+	disallowAll bool
 }
 
 type Rule struct {
-    Agent string
-    Uri   string
-    Allow bool
+	Agent string
+	Uri   string
+	Allow bool
 }
 
 var AllowAll = &RobotsData{allowAll: true}
 var DisallowAll = &RobotsData{disallowAll: true}
 
 func FromResponseBytes(statusCode int, body []byte, print_errors bool) (*RobotsData, error) {
-    switch {
-    case statusCode == 404:
-        return AllowAll, nil
-    case statusCode == 401 || statusCode == 403:
-        return DisallowAll, nil
-    case statusCode >= 200 && statusCode < 300:
-        return FromBytes(body, print_errors)
-    }
-    // Conservative disallow all default
-    return DisallowAll, nil
+	switch {
+	case statusCode == 404:
+		return AllowAll, nil
+	case statusCode == 401 || statusCode == 403:
+		return DisallowAll, nil
+	case statusCode >= 200 && statusCode < 300:
+		return FromBytes(body, print_errors)
+	}
+	// Conservative disallow all default
+	return DisallowAll, nil
 }
 
 func FromResponse(statusCode int, body string, print_errors bool) (*RobotsData, error) {
-    return FromResponseBytes(statusCode, []byte(body), print_errors)
+	return FromResponseBytes(statusCode, []byte(body), print_errors)
 }
 
 func FromBytes(body []byte, print_errors bool) (r *RobotsData, err error) {
-    // special case (probably not worth optimization?)
-    trimmed := bytes.TrimSpace(body)
-    if len(trimmed) == 0 {
-        return AllowAll, nil
-    }
+	// special case (probably not worth optimization?)
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return AllowAll, nil
+	}
 
-    sc := NewByteScanner("bytes", false)
-    sc.Quiet = !print_errors
-    sc.Feed(body, true)
-    var tokens []string
-    tokens, err = sc.ScanAll()
-    if err != nil {
-        return nil, err
-    }
+	sc := NewByteScanner("bytes", false)
+	sc.Quiet = !print_errors
+	sc.Feed(body, true)
+	var tokens []string
+	tokens, err = sc.ScanAll()
+	if err != nil {
+		return nil, err
+	}
 
-    // special case worth optimization
-    if len(tokens) == 0 {
-        return AllowAll, nil
-    }
+	// special case worth optimization
+	if len(tokens) == 0 {
+		return AllowAll, nil
+	}
 
-    r = &RobotsData{}
-    parser := NewParser(tokens)
-    r.rules, err = parser.ParseAll()
+	r = &RobotsData{}
+	parser := NewParser(tokens)
+	r.rules, err = parser.ParseAll()
 
-    return r, err
+	return r, err
 }
 
 func FromString(body string, print_errors bool) (r *RobotsData, err error) {
-    return FromBytes([]byte(body), print_errors)
+	return FromBytes([]byte(body), print_errors)
 }
 
 func (r *RobotsData) Test(url string) (bool, error) {
-    if r.DefaultAgent == "" {
-        return false, errors.New("DefaultAgent is empty. You MUST set RobotsData.DefaultAgent to use Test method.")
-    }
-    return r.TestAgent(url, r.DefaultAgent)
+	if r.DefaultAgent == "" {
+		return false, errors.New("DefaultAgent is empty. You MUST set RobotsData.DefaultAgent to use Test method.")
+	}
+	return r.TestAgent(url, r.DefaultAgent)
 }
 
 func (r *RobotsData) TestAgent(url, agent string) (allow bool, err error) {
-    if r.allowAll {
-        return true, nil
-    }
-    if r.disallowAll {
-        return false, nil
-    }
+	if r.allowAll {
+		return true, nil
+	}
+	if r.disallowAll {
+		return false, nil
+	}
 
-    // optimistic
-    allow = true
-    for _, rule := range r.rules {
-        if rule.MatchAgent(agent) && rule.MatchUrl(url) {
-            allow = rule.Allow
-            // stop on first disallow as safety default
-            // in absense of better algorithm
-            if !rule.Allow {
-                break
-            }
-        }
-    }
+	// optimistic
+	allow = true
+	for _, rule := range r.rules {
+		if rule.MatchAgent(agent) && rule.MatchUrl(url) {
+			allow = rule.Allow
+			// stop on first disallow as safety default
+			// in absense of better algorithm
+			if !rule.Allow {
+				break
+			}
+		}
+	}
 
-    return allow, nil
+	return allow, nil
 }
 
 func (rule *Rule) MatchAgent(agent string) bool {
-    l_agent := strings.ToLower(agent)
-    l_rule_agent := strings.ToLower(rule.Agent)
-    return rule.Agent == "*" || strings.HasPrefix(l_agent, l_rule_agent)
+	l_agent := strings.ToLower(agent)
+	l_rule_agent := strings.ToLower(rule.Agent)
+	return rule.Agent == "*" || strings.HasPrefix(l_agent, l_rule_agent)
 }
 
 func (rule *Rule) MatchUrl(url string) bool {
-    return strings.HasPrefix(url, rule.Uri)
+	return strings.HasPrefix(url, rule.Uri)
 }
 
 func (rule *Rule) String() string {
-    allow_str := "Disallow"
-    if rule.Allow {
-        allow_str = "Allow"
-    }
-    return "<" + allow_str + " " + rule.Agent + " " + rule.Uri + ">"
+	allow_str := "Disallow"
+	if rule.Allow {
+		allow_str = "Allow"
+	}
+	return "<" + allow_str + " " + rule.Agent + " " + rule.Uri + ">"
 }

--- a/robotstxt_test.go
+++ b/robotstxt_test.go
@@ -1,221 +1,218 @@
 package robotstxt
 
 import (
-    "testing"
+	"testing"
 )
 
-
 func TestFromResponseBasic(t *testing.T) {
-    if _, err := FromResponse(200, "", true); err != nil {
-        t.Fatal("FromResponse MUST accept 200/\"\"")
-    }
-    if _, err := FromResponse(401, "", true); err != nil {
-        t.Fatal("FromResponse MUST accept 401/\"\"")
-    }
-    if _, err := FromResponse(403, "", true); err != nil {
-        t.Fatal("FromResponse MUST accept 403/\"\"")
-    }
-    if _, err := FromResponse(404, "", true); err != nil {
-        t.Fatal("FromResponse MUST accept 404/\"\"")
-    }
+	if _, err := FromResponse(200, "", true); err != nil {
+		t.Fatal("FromResponse MUST accept 200/\"\"")
+	}
+	if _, err := FromResponse(401, "", true); err != nil {
+		t.Fatal("FromResponse MUST accept 401/\"\"")
+	}
+	if _, err := FromResponse(403, "", true); err != nil {
+		t.Fatal("FromResponse MUST accept 403/\"\"")
+	}
+	if _, err := FromResponse(404, "", true); err != nil {
+		t.Fatal("FromResponse MUST accept 404/\"\"")
+	}
 }
 
 func _expectAllow(r *RobotsData, t *testing.T) bool {
-    allow, err := r.TestAgent("/", "Somebot")
-    if err != nil {
-        t.Fatal("Unexpected error.")
-    }
-    return allow
+	allow, err := r.TestAgent("/", "Somebot")
+	if err != nil {
+		t.Fatal("Unexpected error.")
+	}
+	return allow
 }
 
 func ExpectAllow(r *RobotsData, t *testing.T, msg string) {
-    if !_expectAllow(r, t) {
-        t.Fatal(msg)
-    }
+	if !_expectAllow(r, t) {
+		t.Fatal(msg)
+	}
 }
 
 func ExpectDisallow(r *RobotsData, t *testing.T, msg string) {
-    if _expectAllow(r, t) {
-        t.Fatal(msg)
-    }
+	if _expectAllow(r, t) {
+		t.Fatal(msg)
+	}
 }
 
-
 func TestResponse401(t *testing.T) {
-    r, _ := FromResponse(401, "", true)
-    ExpectDisallow(r, t, "FromResponse(401, \"\") MUST disallow everything.")
+	r, _ := FromResponse(401, "", true)
+	ExpectDisallow(r, t, "FromResponse(401, \"\") MUST disallow everything.")
 }
 
 func TestResponse403(t *testing.T) {
-    r, _ := FromResponse(403, "", true)
-    ExpectDisallow(r, t, "FromResponse(403, \"\") MUST disallow everything.")
+	r, _ := FromResponse(403, "", true)
+	ExpectDisallow(r, t, "FromResponse(403, \"\") MUST disallow everything.")
 }
 
 func TestResponse404(t *testing.T) {
-    r, _ := FromResponse(404, "", true)
-    ExpectAllow(r, t, "FromResponse(404, \"\") MUST allow everything.")
+	r, _ := FromResponse(404, "", true)
+	ExpectAllow(r, t, "FromResponse(404, \"\") MUST allow everything.")
 }
 
-
 func TestFromStringBasic(t *testing.T) {
-    if _, err := FromString("", true); err != nil {
-        t.Fatal("FromString MUST accept \"\"")
-    }
+	if _, err := FromString("", true); err != nil {
+		t.Fatal("FromString MUST accept \"\"")
+	}
 }
 
 func TestFromStringEmpty(t *testing.T) {
-    r, _ := FromString("", true)
-    if allow, err := r.TestAgent("/", "Somebot"); err != nil || !allow {
-        t.Fatal("FromString(\"\") MUST allow everything.")
-    }
+	r, _ := FromString("", true)
+	if allow, err := r.TestAgent("/", "Somebot"); err != nil || !allow {
+		t.Fatal("FromString(\"\") MUST allow everything.")
+	}
 }
 
 func TestFromStringComment(t *testing.T) {
-    if _, err := FromString("# comment", true); err != nil {
-        t.Fatal("FromString MUST accept \"# comment\"")
-    }
+	if _, err := FromString("# comment", true); err != nil {
+		t.Fatal("FromString MUST accept \"# comment\"")
+	}
 }
 
 func TestFromString001(t *testing.T) {
-    r, err := FromString("User-Agent: *\r\nDisallow: /\r\n", true)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    allow, err1 := r.TestAgent("/foobar", "SomeAgent")
-    if err1 != nil {
-        t.Fatal(err1.Error())
-    }
-    if allow {
-        t.Fatal("Must deny.")
-    }
+	r, err := FromString("User-Agent: *\r\nDisallow: /\r\n", true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	allow, err1 := r.TestAgent("/foobar", "SomeAgent")
+	if err1 != nil {
+		t.Fatal(err1.Error())
+	}
+	if allow {
+		t.Fatal("Must deny.")
+	}
 }
 
 func TestFromString002(t *testing.T) {
-    r, err := FromString("User-Agent: *\r\nDisallow: /account\r\n", true)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    allow, err1 := r.TestAgent("/foobar", "SomeAgent")
-    if err1 != nil {
-        t.Fatal(err1.Error())
-    }
-    if !allow {
-        t.Fatal("Must allow.")
-    }
+	r, err := FromString("User-Agent: *\r\nDisallow: /account\r\n", true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	allow, err1 := r.TestAgent("/foobar", "SomeAgent")
+	if err1 != nil {
+		t.Fatal(err1.Error())
+	}
+	if !allow {
+		t.Fatal("Must allow.")
+	}
 }
 
 const robots_text_001 = "User-agent: * \nDisallow: /administrator/\nDisallow: /cache/\nDisallow: /components/\nDisallow: /editor/\nDisallow: /forum/\nDisallow: /help/\nDisallow: /images/\nDisallow: /includes/\nDisallow: /language/\nDisallow: /mambots/\nDisallow: /media/\nDisallow: /modules/\nDisallow: /templates/\nDisallow: /installation/\nDisallow: /getcid/\nDisallow: /tooltip/\nDisallow: /getuser/\nDisallow: /download/\nDisallow: /index.php?option=com_phorum*,quote=1\nDisallow: /index.php?option=com_phorum*phorum_query=search\nDisallow: /index.php?option=com_phorum*,newer\nDisallow: /index.php?option=com_phorum*,older\n\nUser-agent: Yandex\nAllow: /\nSitemap: http://www.pravorulya.com/sitemap.xml\nSitemap: http://www.pravorulya.com/sitemap1.xml"
 
 func TestFromString003(t *testing.T) {
-    r, err := FromString(robots_text_001, true)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    allow, err1 := r.TestAgent("/administrator/", "SomeBot")
-    if err1 != nil {
-        t.Fatal(err1.Error())
-    }
-    if allow {
-        t.Fatal("Must deny.")
-    }
+	r, err := FromString(robots_text_001, true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	allow, err1 := r.TestAgent("/administrator/", "SomeBot")
+	if err1 != nil {
+		t.Fatal(err1.Error())
+	}
+	if allow {
+		t.Fatal("Must deny.")
+	}
 }
 
 func TestFromString004(t *testing.T) {
-    r, err := FromString(robots_text_001, true)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    allow, err1 := r.TestAgent("/paruram", "SomeBot")
-    if err1 != nil {
-        t.Fatal(err1.Error())
-    }
-    if !allow {
-        t.Fatal("Must allow.")
-    }
+	r, err := FromString(robots_text_001, true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	allow, err1 := r.TestAgent("/paruram", "SomeBot")
+	if err1 != nil {
+		t.Fatal(err1.Error())
+	}
+	if !allow {
+		t.Fatal("Must allow.")
+	}
 }
 
 func TestInvalidEncoding(t *testing.T) {
-    // Invalid UTF-8 encoding should not break parser.
-    _, err := FromString("User-agent: H\xef\xbf\xbdm�h�kki\nDisallow: *", true)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
+	// Invalid UTF-8 encoding should not break parser.
+	_, err := FromString("User-agent: H\xef\xbf\xbdm�h�kki\nDisallow: *", true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 }
 
 // http://www.google.com/robots.txt on Wed, 12 Jan 2011 12:22:20 GMT
 const robots_text_002 = ("User-agent: *\nDisallow: /search\nDisallow: /groups\nDisallow: /images\nDisallow: /catalogs\nDisallow: /catalogues\nDisallow: /news\nAllow: /news/directory\nDisallow: /nwshp\nDisallow: /setnewsprefs?\nDisallow: /index.html?\nDisallow: /?\nDisallow: /addurl/image?\nDisallow: /pagead/\nDisallow: /relpage/\nDisallow: /relcontent\nDisallow: /imgres\nDisallow: /imglanding\nDisallow: /keyword/\nDisallow: /u/\nDisallow: /univ/\nDisallow: /cobrand\nDisallow: /custom\nDisallow: /advanced_group_search\nDisallow: /googlesite\nDisallow: /preferences\nDisallow: /setprefs\nDisallow: /swr\nDisallow: /url\nDisallow: /default\nDisallow: /m?\nDisallow: /m/?\nDisallow: /m/blogs?\nDisallow: /m/directions?\nDisallow: /m/ig\nDisallow: /m/images?\nDisallow: /m/local?\nDisallow: /m/movies?\nDisallow: /m/news?\nDisallow: /m/news/i?\nDisallow: /m/place?\nDisallow: /m/products?\nDisallow: /m/products/\nDisallow: /m/setnewsprefs?\nDisallow: /m/search?\nDisallow: /m/swmloptin?\nDisallow: /m/trends\nDisallow: /m/video?\nDisallow: /wml?\nDisallow: /wml/?\nDisallow: /wml/search?\nDisallow: /xhtml?\nDisallow: /xhtml/?\nDisallow: /xhtml/search?\nDisallow: /xml?\nDisallow: /imode?\nDisallow: /imode/?\nDisallow: /imode/search?\nDisallow: /jsky?\nDisallow: /jsky/?\nDisallow: /jsky/search?\nDisallow: /pda?\nDisallow: /pda/?\nDisallow: /pda/search?\nDisallow: /sprint_xhtml\nDisallow: /sprint_wml\nDisallow: /pqa\nDisallow: /palm\nDisallow: /gwt/\nDisallow: /purchases\nDisallow: /hws\nDisallow: /bsd?\nDisallow: /linux?\nDisallow: /mac?\nDisallow: /microsoft?\nDisallow: /unclesam?\nDisallow: /answers/search?q=\nDisallow: /local?\nDisallow: /local_url\nDisallow: /froogle?\nDisallow: /products?\nDisallow: /products/\nDisallow: /froogle_\nDisallow: /product_\nDisallow: /products_\nDisallow: /products;\nDisallow: /print\nDisallow: /books\nDisallow: /bkshp?q=\nAllow: /booksrightsholders\nDisallow: /patents?\nDisallow: /patents/\nAllow: /patents/about\nDisallow: /scholar\nDisallow: /complete\nDisallow: /sponsoredlinks\nDisallow: /videosearch?\nDisallow: /videopreview?\nDisallow: /videoprograminfo?\nDisallow: /maps?\nDisallow: /mapstt?\nDisallow: /mapslt?\nDisallow: /maps/stk/\nDisallow: /maps/br?\nDisallow: /mapabcpoi?\nDisallow: /maphp?\nDisallow: /places/\nAllow: /places/$\nDisallow: /maps/place\nDisallow: /help/maps/streetview/partners/welcome/\nDisallow: /lochp?\nDisallow: /center\nDisallow: /ie?\nDisallow: /sms/demo?\nDisallow: /katrina?\nDisallow: /blogsearch?\nDisallow: /blogsearch/\nDisallow: /blogsearch_feeds\nDisallow: /advanced_blog_search\nDisallow: /reader/\nAllow: /reader/play\nDisallow: /uds/\nDisallow: /chart?\nDisallow: /transit?\nDisallow: /mbd?\nDisallow: /extern_js/\nDisallow: /calendar/feeds/\nDisallow: /calendar/ical/\nDisallow: /cl2/feeds/\n" +
-                         "Disallow: /cl2/ical/\nDisallow: /coop/directory\nDisallow: /coop/manage\nDisallow: /trends?\nDisallow: /trends/music?\nDisallow: /trends/hottrends?\nDisallow: /trends/viz?\nDisallow: /notebook/search?\nDisallow: /musica\nDisallow: /musicad\nDisallow: /musicas\nDisallow: /musicl\nDisallow: /musics\nDisallow: /musicsearch\nDisallow: /musicsp\nDisallow: /musiclp\nDisallow: /browsersync\nDisallow: /call\nDisallow: /archivesearch?\nDisallow: /archivesearch/url\nDisallow: /archivesearch/advanced_search\nDisallow: /base/reportbadoffer\nDisallow: /urchin_test/\nDisallow: /movies?\nDisallow: /codesearch?\nDisallow: /codesearch/feeds/search?\nDisallow: /wapsearch?\nDisallow: /safebrowsing\nAllow: /safebrowsing/diagnostic\nAllow: /safebrowsing/report_error/\nAllow: /safebrowsing/report_phish/\nDisallow: /reviews/search?\nDisallow: /orkut/albums\nAllow: /jsapi\nDisallow: /views?\nDisallow: /c/\nDisallow: /cbk\nDisallow: /recharge/dashboard/car\nDisallow: /recharge/dashboard/static/\nDisallow: /translate_a/\nDisallow: /translate_c\nDisallow: /translate_f\nDisallow: /translate_static/\nDisallow: /translate_suggestion\nDisallow: /profiles/me\nAllow: /profiles\nDisallow: /s2/profiles/me\nAllow: /s2/profiles\nAllow: /s2/photos\nAllow: /s2/static\nDisallow: /s2\nDisallow: /transconsole/portal/\nDisallow: /gcc/\nDisallow: /aclk\nDisallow: /cse?\nDisallow: /cse/home\nDisallow: /cse/panel\nDisallow: /cse/manage\nDisallow: /tbproxy/\nDisallow: /imesync/\nDisallow: /shenghuo/search?\nDisallow: /support/forum/search?\nDisallow: /reviews/polls/\nDisallow: /hosted/images/\nDisallow: /ppob/?\nDisallow: /ppob?\nDisallow: /ig/add?\nDisallow: /adwordsresellers\nDisallow: /accounts/o8\nAllow: /accounts/o8/id\nDisallow: /topicsearch?q=\nDisallow: /xfx7/\nDisallow: /squared/api\nDisallow: /squared/search\nDisallow: /squared/table\nDisallow: /toolkit/\nAllow: /toolkit/*.html\nDisallow: /globalmarketfinder/\nAllow: /globalmarketfinder/*.html\nDisallow: /qnasearch?\nDisallow: /errors/\nDisallow: /app/updates\nDisallow: /sidewiki/entry/\nDisallow: /quality_form?\nDisallow: /labs/popgadget/search\nDisallow: /buzz/post\nDisallow: /compressiontest/\nDisallow: /analytics/reporting/\nDisallow: /analytics/admin/\nDisallow: /analytics/web/\nDisallow: /analytics/feeds/\nDisallow: /analytics/settings/\nDisallow: /alerts/\nDisallow: /phone/compare/?\nAllow: /alerts/manage\nSitemap: http://www.gstatic.com/s2/sitemaps/profiles-sitemap.xml\nSitemap: http://www.google.com/hostednews/sitemap_index.xml\nSitemap: http://www.google.com/ventures/sitemap_ventures.xml\nSitemap: http://www.google.com/sitemaps_webmasters.xml\nSitemap: http://www.gstatic.com/trends/websites/sitemaps/sitemapindex.xml\nSitemap: http://www.gstatic.com/dictionary/static/sitemaps/sitemap_index.xml")
+	"Disallow: /cl2/ical/\nDisallow: /coop/directory\nDisallow: /coop/manage\nDisallow: /trends?\nDisallow: /trends/music?\nDisallow: /trends/hottrends?\nDisallow: /trends/viz?\nDisallow: /notebook/search?\nDisallow: /musica\nDisallow: /musicad\nDisallow: /musicas\nDisallow: /musicl\nDisallow: /musics\nDisallow: /musicsearch\nDisallow: /musicsp\nDisallow: /musiclp\nDisallow: /browsersync\nDisallow: /call\nDisallow: /archivesearch?\nDisallow: /archivesearch/url\nDisallow: /archivesearch/advanced_search\nDisallow: /base/reportbadoffer\nDisallow: /urchin_test/\nDisallow: /movies?\nDisallow: /codesearch?\nDisallow: /codesearch/feeds/search?\nDisallow: /wapsearch?\nDisallow: /safebrowsing\nAllow: /safebrowsing/diagnostic\nAllow: /safebrowsing/report_error/\nAllow: /safebrowsing/report_phish/\nDisallow: /reviews/search?\nDisallow: /orkut/albums\nAllow: /jsapi\nDisallow: /views?\nDisallow: /c/\nDisallow: /cbk\nDisallow: /recharge/dashboard/car\nDisallow: /recharge/dashboard/static/\nDisallow: /translate_a/\nDisallow: /translate_c\nDisallow: /translate_f\nDisallow: /translate_static/\nDisallow: /translate_suggestion\nDisallow: /profiles/me\nAllow: /profiles\nDisallow: /s2/profiles/me\nAllow: /s2/profiles\nAllow: /s2/photos\nAllow: /s2/static\nDisallow: /s2\nDisallow: /transconsole/portal/\nDisallow: /gcc/\nDisallow: /aclk\nDisallow: /cse?\nDisallow: /cse/home\nDisallow: /cse/panel\nDisallow: /cse/manage\nDisallow: /tbproxy/\nDisallow: /imesync/\nDisallow: /shenghuo/search?\nDisallow: /support/forum/search?\nDisallow: /reviews/polls/\nDisallow: /hosted/images/\nDisallow: /ppob/?\nDisallow: /ppob?\nDisallow: /ig/add?\nDisallow: /adwordsresellers\nDisallow: /accounts/o8\nAllow: /accounts/o8/id\nDisallow: /topicsearch?q=\nDisallow: /xfx7/\nDisallow: /squared/api\nDisallow: /squared/search\nDisallow: /squared/table\nDisallow: /toolkit/\nAllow: /toolkit/*.html\nDisallow: /globalmarketfinder/\nAllow: /globalmarketfinder/*.html\nDisallow: /qnasearch?\nDisallow: /errors/\nDisallow: /app/updates\nDisallow: /sidewiki/entry/\nDisallow: /quality_form?\nDisallow: /labs/popgadget/search\nDisallow: /buzz/post\nDisallow: /compressiontest/\nDisallow: /analytics/reporting/\nDisallow: /analytics/admin/\nDisallow: /analytics/web/\nDisallow: /analytics/feeds/\nDisallow: /analytics/settings/\nDisallow: /alerts/\nDisallow: /phone/compare/?\nAllow: /alerts/manage\nSitemap: http://www.gstatic.com/s2/sitemaps/profiles-sitemap.xml\nSitemap: http://www.google.com/hostednews/sitemap_index.xml\nSitemap: http://www.google.com/ventures/sitemap_ventures.xml\nSitemap: http://www.google.com/sitemaps_webmasters.xml\nSitemap: http://www.gstatic.com/trends/websites/sitemaps/sitemapindex.xml\nSitemap: http://www.gstatic.com/dictionary/static/sitemaps/sitemap_index.xml")
 
 func TestFromString005(t *testing.T) {
-    r, err := FromString(robots_text_002, true)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    ExpectAllow(r, t, "Must allow.")
+	r, err := FromString(robots_text_002, true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	ExpectAllow(r, t, "Must allow.")
 }
 
 func TestFromString006(t *testing.T) {
-    r, err := FromString(robots_text_002, true)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    allow, err1 := r.TestAgent("/search", "SomeBot")
-    if err1 != nil {
-        t.Fatal(err1.Error())
-    }
-    if allow {
-        t.Fatal("Must deny.")
-    }
+	r, err := FromString(robots_text_002, true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	allow, err1 := r.TestAgent("/search", "SomeBot")
+	if err1 != nil {
+		t.Fatal(err1.Error())
+	}
+	if allow {
+		t.Fatal("Must deny.")
+	}
 }
 
 const robots_text_003 = "User-Agent: * \nAllow: /"
 
 func TestFromString007(t *testing.T) {
-    r, err := FromString(robots_text_003, true)
-    if err != nil {
-        t.Fatal(err.String())
-    }
-    allow, err1 := r.TestAgent("/random", "SomeBot")
-    if err1 != nil {
-        t.Fatal(err1.String())
-    }
-    if !allow {
-        t.Fatal("Must allow.")
-    }
+	r, err := FromString(robots_text_003, true)
+	if err != nil {
+		t.Fatal(err.String())
+	}
+	allow, err1 := r.TestAgent("/random", "SomeBot")
+	if err1 != nil {
+		t.Fatal(err1.String())
+	}
+	if !allow {
+		t.Fatal("Must allow.")
+	}
 }
 
 const robots_text_004 = "User-Agent: * \nDisallow: "
 
 func TestFromString008(t *testing.T) {
-    r, err := FromString(robots_text_004, true)
-    if err != nil {
-        t.Fatal(err.String())
-    }
-    allow, err1 := r.TestAgent("/random", "SomeBot")
-    if err1 != nil {
-        t.Fatal(err1.String())
-    }
-    if !allow {
-        t.Fatal("Must allow.")
-    }
+	r, err := FromString(robots_text_004, true)
+	if err != nil {
+		t.Fatal(err.String())
+	}
+	allow, err1 := r.TestAgent("/random", "SomeBot")
+	if err1 != nil {
+		t.Fatal(err1.String())
+	}
+	if !allow {
+		t.Fatal("Must allow.")
+	}
 }
 
 func BenchmarkParseFromString001(b *testing.B) {
-    for i := 0; i < b.N; i++ {
-        FromString(robots_text_001, false)
-        b.SetBytes(int64(len(robots_text_001)))
-    }
+	for i := 0; i < b.N; i++ {
+		FromString(robots_text_001, false)
+		b.SetBytes(int64(len(robots_text_001)))
+	}
 }
 
 func BenchmarkParseFromString002(b *testing.B) {
-    for i := 0; i < b.N; i++ {
-        FromString(robots_text_002, false)
-        b.SetBytes(int64(len(robots_text_002)))
-    }
+	for i := 0; i < b.N; i++ {
+		FromString(robots_text_002, false)
+		b.SetBytes(int64(len(robots_text_002)))
+	}
 }
 
 func BenchmarkParseFromResponse401(b *testing.B) {
-    for i := 0; i < b.N; i++ {
-        FromResponse(401, "", false)
-    }
+	for i := 0; i < b.N; i++ {
+		FromResponse(401, "", false)
+	}
 }

--- a/scanner.go
+++ b/scanner.go
@@ -1,189 +1,189 @@
 package robotstxt
 
 import (
-    "fmt"
-    "go/token"
-    "io"
-    "os"
-    "unicode/utf8"
+	"fmt"
+	"go/token"
+	"io"
+	"os"
+	"unicode/utf8"
 )
 
 type ByteScanner struct {
-    ErrorCount int
-    Quiet      bool
+	ErrorCount int
+	Quiet      bool
 
-    buf       []byte
-    pos       token.Position
-    lastChunk bool
-    ch        rune
-    //
-    //state string
+	buf       []byte
+	pos       token.Position
+	lastChunk bool
+	ch        rune
+	//
+	//state string
 }
 
 var WhitespaceChars = []rune{' ', '\t', '\v'}
 
 func NewByteScanner(srcname string, quiet bool) *ByteScanner {
-    return &ByteScanner{
-        Quiet: quiet,
-        ch:    -1,
-        pos:   token.Position{Filename: srcname},
-        //state: "start",
-    }
+	return &ByteScanner{
+		Quiet: quiet,
+		ch:    -1,
+		pos:   token.Position{Filename: srcname},
+		//state: "start",
+	}
 }
 
 func (s *ByteScanner) Feed(input []byte, end bool) (bool, error) {
-    s.buf = input
-    s.pos.Offset = 0
-    s.pos.Line = 1
-    s.pos.Column = 1
-    s.lastChunk = end
-    // Read first char into look-ahead buffer `s.ch`.
-    s.nextChar()
-    return false, nil
+	s.buf = input
+	s.pos.Offset = 0
+	s.pos.Line = 1
+	s.pos.Column = 1
+	s.lastChunk = end
+	// Read first char into look-ahead buffer `s.ch`.
+	s.nextChar()
+	return false, nil
 }
 
 func (s *ByteScanner) GetPosition() token.Position {
-    return s.pos
+	return s.pos
 }
 
 func (s *ByteScanner) Scan() (string, error) {
-    //println("--- Scan(). Offset / len(s.buf): ", s.pos.Offset, len(s.buf))
+	//println("--- Scan(). Offset / len(s.buf): ", s.pos.Offset, len(s.buf))
 
-    bufsize := len(s.buf)
-    for {
-        // Note Offset > len, not >=, so we can Scan last character.
-        if s.lastChunk && s.pos.Offset > bufsize {
-            return "", io.EOF
-        }
+	bufsize := len(s.buf)
+	for {
+		// Note Offset > len, not >=, so we can Scan last character.
+		if s.lastChunk && s.pos.Offset > bufsize {
+			return "", io.EOF
+		}
 
-        s.skipSpace()
+		s.skipSpace()
 
-        if s.ch == -1 {
-            return "", io.EOF
-        }
+		if s.ch == -1 {
+			return "", io.EOF
+		}
 
-        // EOL
-        if s.isEol() {
-            // skip subsequent newline chars
-            for s.ch != -1 && s.isEol() {
-                s.nextChar()
-            }
-            // emit newline as separate token
-            return "\n", nil
-        }
+		// EOL
+		if s.isEol() {
+			// skip subsequent newline chars
+			for s.ch != -1 && s.isEol() {
+				s.nextChar()
+			}
+			// emit newline as separate token
+			return "\n", nil
+		}
 
-        // skip comments
-        if s.ch == '#' {
-            s.skipUntilEol()
-            //            s.state = "start"
-            if s.ch == -1 {
-                return "", io.EOF
-            }
-            // emit newline as separate token
-            return "\n", nil
-        }
+		// skip comments
+		if s.ch == '#' {
+			s.skipUntilEol()
+			//            s.state = "start"
+			if s.ch == -1 {
+				return "", io.EOF
+			}
+			// emit newline as separate token
+			return "\n", nil
+		}
 
-        // else we found something
-        break
-    }
+		// else we found something
+		break
+	}
 
-    /*
-       if s.state == "start" {
-           s.state = "key"
-       }
-    */
+	/*
+	   if s.state == "start" {
+	       s.state = "key"
+	   }
+	*/
 
-    tok := string(s.ch)
-    s.nextChar()
-    for s.ch != -1 && !s.isSpace() && !s.isEol() {
-        if s.ch == ':' {
-            //            s.state = "pre-value"
-            s.nextChar()
-            break
-        }
+	tok := string(s.ch)
+	s.nextChar()
+	for s.ch != -1 && !s.isSpace() && !s.isEol() {
+		if s.ch == ':' {
+			//            s.state = "pre-value"
+			s.nextChar()
+			break
+		}
 
-        tok += string(s.ch)
-        s.nextChar()
-    }
-    return tok, nil
+		tok += string(s.ch)
+		s.nextChar()
+	}
+	return tok, nil
 }
 
 func (s *ByteScanner) ScanAll() ([]string, error) {
-    var results []string
-    for {
-        t, err := s.Scan()
-        if t != "" {
-            results = append(results, t)
-        }
-        if err == io.EOF {
-            break
-        }
-        if err != nil {
-            return results, err
-        }
-    }
-    return results, nil
+	var results []string
+	for {
+		t, err := s.Scan()
+		if t != "" {
+			results = append(results, t)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return results, err
+		}
+	}
+	return results, nil
 }
 
 func (s *ByteScanner) error(pos token.Position, msg string) {
-    s.ErrorCount++
-    if !s.Quiet {
-        fmt.Fprintf(os.Stderr, "robotstxt from %s: %s\n", pos.String(), msg)
-    }
+	s.ErrorCount++
+	if !s.Quiet {
+		fmt.Fprintf(os.Stderr, "robotstxt from %s: %s\n", pos.String(), msg)
+	}
 }
 
 func (s *ByteScanner) isEol() bool {
-    return s.ch == '\n' || s.ch == '\r'
+	return s.ch == '\n' || s.ch == '\r'
 }
 
 func (s *ByteScanner) isSpace() bool {
-    for i, _ := range WhitespaceChars {
-        if s.ch == WhitespaceChars[i] {
-            return true
-        }
-    }
-    return false
+	for _, r := range WhitespaceChars {
+		if s.ch == r {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *ByteScanner) skipSpace() {
-    //println("--- string(ch): ", s.ch, ".")
-    for s.ch != -1 && s.isSpace() {
-        s.nextChar()
-    }
+	//println("--- string(ch): ", s.ch, ".")
+	for s.ch != -1 && s.isSpace() {
+		s.nextChar()
+	}
 }
 
 func (s *ByteScanner) skipUntilEol() {
-    //println("--- string(ch): ", s.ch, ".")
-    for s.ch != -1 && !s.isEol() {
-        s.nextChar()
-    }
-    // skip subsequent newline chars
-    for s.ch != -1 && s.isEol() {
-        s.nextChar()
-    }
+	//println("--- string(ch): ", s.ch, ".")
+	for s.ch != -1 && !s.isEol() {
+		s.nextChar()
+	}
+	// skip subsequent newline chars
+	for s.ch != -1 && s.isEol() {
+		s.nextChar()
+	}
 }
 
 // Reads next Unicode char.
 func (s *ByteScanner) nextChar() (rune, error) {
-    //println("--- nextChar(). Offset / len(s.buf): ", s.pos.Offset, len(s.buf))
+	//println("--- nextChar(). Offset / len(s.buf): ", s.pos.Offset, len(s.buf))
 
-    if s.pos.Offset >= len(s.buf) {
-        s.ch = -1
-        return s.ch, io.EOF
-    }
-    s.pos.Column++
-    if s.ch == '\n' {
-        s.pos.Line++
-        s.pos.Column = 1
-    }
-    r, w := rune(s.buf[s.pos.Offset]), 1
-    if r >= 0x80 {
-        r, w = utf8.DecodeRune(s.buf[s.pos.Offset:])
-        if r == utf8.RuneError && w == 1 {
-            s.error(s.pos, "illegal UTF-8 encoding")
-        }
-    }
-    s.pos.Offset += w
-    s.ch = r
-    return s.ch, nil
+	if s.pos.Offset >= len(s.buf) {
+		s.ch = -1
+		return s.ch, io.EOF
+	}
+	s.pos.Column++
+	if s.ch == '\n' {
+		s.pos.Line++
+		s.pos.Column = 1
+	}
+	r, w := rune(s.buf[s.pos.Offset]), 1
+	if r >= 0x80 {
+		r, w = utf8.DecodeRune(s.buf[s.pos.Offset:])
+		if r == utf8.RuneError && w == 1 {
+			s.error(s.pos, "illegal UTF-8 encoding")
+		}
+	}
+	s.pos.Offset += w
+	s.ch = r
+	return s.ch, nil
 }

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,82 +1,81 @@
 package robotstxt
 
 import (
-//    "os"
-    "strconv"
-    "testing"
+	//    "os"
+	"strconv"
+	"testing"
 )
 
-
 func TestScan001(t *testing.T) {
-    sc := NewByteScanner("test-001", false)
-    if _, err := sc.Scan(); err == nil {
-        t.Fatal("Empty ByteScanner should fail on Scan.")
-    }
+	sc := NewByteScanner("test-001", false)
+	if _, err := sc.Scan(); err == nil {
+		t.Fatal("Empty ByteScanner should fail on Scan.")
+	}
 }
 
 func TestScan002(t *testing.T) {
-    sc := NewByteScanner("test-002", false)
-    sc.Feed( []byte("foo") , true)
-    _, err := sc.Scan()
-    //print("---", tok, err)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
+	sc := NewByteScanner("test-002", false)
+	sc.Feed([]byte("foo"), true)
+	_, err := sc.Scan()
+	//print("---", tok, err)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 }
 
 func TestScan004(t *testing.T) {
-    sc := NewByteScanner("test-004", false)
-    sc.Feed( []byte("\u2010") , true)
-    _, err := sc.Scan()
-    //println("---", tok, err)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
+	sc := NewByteScanner("test-004", false)
+	sc.Feed([]byte("\u2010"), true)
+	_, err := sc.Scan()
+	//println("---", tok, err)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 }
 
 func TestScan005(t *testing.T) {
-    sc := NewByteScanner("test-005", true)
-    sc.Feed( []byte("\xd9\xd9") , true)
-    _, err := sc.Scan()
-    //println("---", tok, err)
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    if sc.ErrorCount != 2 {
-        t.Fatal("Expecting ErrorCount be exactly 2.")
-    }
+	sc := NewByteScanner("test-005", true)
+	sc.Feed([]byte("\xd9\xd9"), true)
+	_, err := sc.Scan()
+	//println("---", tok, err)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if sc.ErrorCount != 2 {
+		t.Fatal("Expecting ErrorCount be exactly 2.")
+	}
 }
 
 func TestScan006(t *testing.T) {
-    sc := NewByteScanner("test-006", false)
-    s := "# comment \r\nSomething: Somewhere\r\n"
-    sc.Feed( []byte(s) , true)
-    tokens, err := sc.ScanAll()
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    //println("--- len(tokens):", len(tokens))
-    if len(tokens) != 4 {
-        t.Fatal("Expecting exactly 4 tokens.")
-    }
-    if tokens[0] != "\n" || tokens[1] != "Something" || tokens[2] != "Somewhere" || tokens[3] != "\n" {
-        t.Fatal("Wrong tokens read:", strconv.Quote(tokens[0]), strconv.Quote(tokens[1]), strconv.Quote(tokens[2]), strconv.Quote(tokens[3]))
-    }
+	sc := NewByteScanner("test-006", false)
+	s := "# comment \r\nSomething: Somewhere\r\n"
+	sc.Feed([]byte(s), true)
+	tokens, err := sc.ScanAll()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	//println("--- len(tokens):", len(tokens))
+	if len(tokens) != 4 {
+		t.Fatal("Expecting exactly 4 tokens.")
+	}
+	if tokens[0] != "\n" || tokens[1] != "Something" || tokens[2] != "Somewhere" || tokens[3] != "\n" {
+		t.Fatal("Wrong tokens read:", strconv.Quote(tokens[0]), strconv.Quote(tokens[1]), strconv.Quote(tokens[2]), strconv.Quote(tokens[3]))
+	}
 }
 
 func TestScan007(t *testing.T) {
-    sc := NewByteScanner("test-007", false)
-    s := "# comment \r\n# more comments\n\nDisallow:\r"
-    sc.Feed( []byte(s) , true)
-    tokens, err := sc.ScanAll()
-    if err != nil {
-        t.Fatal(err.Error())
-    }
-    //println("--- len(tokens):", len(tokens))
-    if len(tokens) != 4 {
-        t.Fatal("Expecting exactly 4 tokens.")
-    }
-    if tokens[0] != "\n" || tokens[1] != "\n" || tokens[2] != "Disallow" || tokens[3] != "\n" {
-        t.Fatal("Wrong tokens read:", strconv.Quote(tokens[0]), strconv.Quote(tokens[1]), strconv.Quote(tokens[2]), strconv.Quote(tokens[3]))
-    }
+	sc := NewByteScanner("test-007", false)
+	s := "# comment \r\n# more comments\n\nDisallow:\r"
+	sc.Feed([]byte(s), true)
+	tokens, err := sc.ScanAll()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	//println("--- len(tokens):", len(tokens))
+	if len(tokens) != 4 {
+		t.Fatal("Expecting exactly 4 tokens.")
+	}
+	if tokens[0] != "\n" || tokens[1] != "\n" || tokens[2] != "Disallow" || tokens[3] != "\n" {
+		t.Fatal("Wrong tokens read:", strconv.Quote(tokens[0]), strconv.Quote(tokens[1]), strconv.Quote(tokens[2]), strconv.Quote(tokens[3]))
+	}
 }


### PR DESCRIPTION
The tokenizer was calling `isSpace` quite often which was using `strings.Index` to see if the current `rune` was a whitespace character or not.  This involved a type cast and many string comparisons... the attached code simply keeps things in rune space (thus avoiding a memory allocation at each comparison) and is testing comparisons based on frequency of use (so the natural space is the first comparison, then the horizontal tab, then vertical).

Anyways, this small changed sped up the `(*ByteScanner).Scan` operation by about 30%!
