### PR TITLE
Speeding up Parse function

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"unicode/utf8"
+	"bytes"
 )
 
 type byteScanner struct {
@@ -100,7 +101,8 @@ func (s *byteScanner) Scan() (string, error) {
 	   }
 	*/
 
-	tok := string(s.ch)
+	var tok bytes.Buffer
+	tok.WriteString(string(s.ch))
 	s.nextChar()
 	for s.ch != -1 && !s.isSpace() && !s.isEol() {
 		// Do not consider ":" to be a token separator if a first key token
@@ -113,10 +115,10 @@ func (s *byteScanner) Scan() (string, error) {
 			break
 		}
 
-		tok += string(s.ch)
+		tok.WriteString(string(s.ch))
 		s.nextChar()
 	}
-	return tok, nil
+	return tok.String(), nil
 }
 
 func (s *byteScanner) ScanAll() ([]string, error) {


### PR DESCRIPTION
Thanks for this great software!
I used it in a crawler I wrote and had a performance bottleneck in the parse function which pegged the CPU.

You can see a comparison before:
https://files.niels-ole.com/graph.svg
and after:
https://files.niels-ole.com/graph1.svg

If you look at the changed function you can see a performance speedup by 4X (100.10s -> 22.79)*

I am relatively new to golang so beware ;).

Source:
http://stackoverflow.com/questions/1760757/how-to-efficiently-concatenate-strings-in-go

* In the first measurement the CPU was the bottleneck so the second time the program likely was even more effective as the total runtime of the program was a fixed duration.