### PR TITLE
Duplicated user agent groups merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _cgo_*
 _obj
 _test
 coverage.txt
+.idea/*

--- a/google_test.go
+++ b/google_test.go
@@ -84,6 +84,17 @@ Allow: /$
 user-agent: e
 Disallow: /
 Allow: /$`
+
+	robotsGroupDuplicating = `user-agent: *
+	# Added by SEO Ultimate's Link Mask Generator module
+User-agent: *
+Disallow: /go/
+# End Link Mask Generator output
+
+User-agent: *
+Disallow: /wp-admin/
+Disallow: /?s=
+	`
 )
 
 func TestGroupOrder(t *testing.T) {
@@ -314,4 +325,17 @@ func getIndexInSlice(ar []*Group, g *Group) int {
 		}
 	}
 	return -1
+}
+
+func TestRobotsGroupDuplicating(t *testing.T) {
+	if r, e := FromString(robotsGroupDuplicating); e != nil {
+		t.Fatal(e)
+	} else {
+		if r.TestAgent("/go/", "Googlebot") {
+			t.Error("Failed at /go/")
+		}
+		if r.TestAgent("/?s=", "Googlebot") {
+			t.Error("Failed at /?s=")
+		}
+	}
 }

--- a/parser.go
+++ b/parser.go
@@ -52,6 +52,17 @@ func (p *parser) parseAll() (groups []*Group, host string, sitemaps []string, er
 	// Reset internal fields, tokens are assigned at creation time, never change
 	p.pos = 0
 
+	findGroupByUA := func(ua string, groups []*Group) (resGroup *Group) {
+		for _, resGroup = range groups {
+			for _, agent := range resGroup.agents {
+				if agent == ua {
+					return
+				}
+			}
+		}
+		return nil
+	}
+
 	for {
 		if li, err := p.parseLine(); err != nil {
 			if err == io.EOF {
@@ -75,8 +86,11 @@ func (p *parser) parseAll() (groups []*Group, host string, sitemaps []string, er
 					curGroup = nil
 				}
 				if curGroup == nil {
-					curGroup = new(Group)
-					isEmptyGroup = true
+					curGroup = findGroupByUA(li.vs, groups)
+					if curGroup == nil {
+						curGroup = new(Group)
+						isEmptyGroup = true
+					}
 				}
 				// Add the user agent
 				curGroup.agents = append(curGroup.agents, li.vs)


### PR DESCRIPTION
Hello!

Thank you for your library. I found at some websites user agent groups are duplicated.
For example:
```
# Added by SEO Ultimate's Link Mask Generator module
User-agent: *
Disallow: /go/
# End Link Mask Generator output

User-agent: *
Disallow: /wp-admin/
Disallow: /?s=
```
In this case FindGroup finds only first group and returns wrong result.
Please see my changes.

thank you