### PR TITLE
Regexp should match full string

### DIFF
--- a/google_test.go
+++ b/google_test.go
@@ -117,7 +117,7 @@ Disallow: /path*l$`
 
 	r, err := FromString(robotsCaseWildcards)
 	require.NoError(t, err)
-	assert.Equal(t, "/path.*l$", r.groups["*"].rules[0].pattern.String())
+	assert.Equal(t, "^/path.*l$", r.groups["*"].rules[0].pattern.String())
 }
 
 func TestURLMatching(t *testing.T) {
@@ -232,10 +232,12 @@ func TestURLPrecedence(t *testing.T) {
 		"d": {
 			"/",
 			"^/index",
+			"^/dir/",
 		},
 		"e": {
 			"^/page.htm",
 			"/",
+			"^/dir/",
 		},
 	}
 	r, err := FromString(robotsCasePrecedence)

--- a/parser.go
+++ b/parser.go
@@ -185,6 +185,7 @@ func (p *parser) parseLine() (li *lineInfo, err error) {
 				t2 = regexp.QuoteMeta(t2)
 				t2 = strings.Replace(t2, `\*`, `.*`, -1)
 				t2 = strings.Replace(t2, `\$`, `$`, -1)
+				t2 = "^" + t2
 				if r, e := regexp.Compile(t2); e != nil {
 					return nil, e
 				} else {


### PR DESCRIPTION
The current implementation of regexp matcher fails when the pattern is short and the url is long:
```
Allow: /$
```

Should not match with: `/foo/` but only with `/`