### PR TITLE
Initialize field 'Agent' of struct Group

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -51,6 +51,7 @@ func parseGroupMap(groups map[string]*Group, agents []string, fun func(*Group)) 
 	for _, a := range agents {
 		if g = groups[a]; g == nil {
 			g = new(Group)
+			g.Agent = a
 			groups[a] = g
 		}
 		fun(g)

--- a/robotstxt_test.go
+++ b/robotstxt_test.go
@@ -171,6 +171,24 @@ func TestHtmlInstead(t *testing.T) {
 	assert.True(t, group.Test("/"))
 }
 
+func TestFindGroupAgent(t *testing.T) {
+	const robotsTextSimple = `user-agent: wall-e
+disallow: /
+user-agent: *
+allow: /`
+
+	r, err := FromString(robotsTextSimple)
+	require.NoError(t, err)
+
+	group := r.FindGroup("eve")
+	require.NotNil(t, group)
+	assert.Equal(t, "*", group.Agent)
+
+	group = r.FindGroup("wall-e")
+	require.NotNil(t, group)
+	assert.Equal(t, "wall-e", group.Agent)
+}
+
 // http://perche.vanityfair.it/robots.txt on Sat, 13 Sep 2014 23:00:29 GMT
 const robotsTextVanityfair = "\xef\xbb\xbfUser-agent: *\nDisallow: */oroscopo-di-oggi/*"
 


### PR DESCRIPTION
This field was unused throughout the project and was never initialized at instantiation during parsing.