### PR TITLE
ci: missed coverage report flags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,5 +64,8 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: go test -race
+        if: ${{ ! matrix.coverage }}
+      - run: go test -race -covermode=atomic -coverprofile=coverage.txt
+        if: matrix.coverage
       - uses: codecov/codecov-action@v2
         if: matrix.coverage


### PR DESCRIPTION
PR only to verify codecov report.