### PR TITLE
Make the `AllowAll` and `DisallowAll` instances public

### DIFF
--- a/robotstxt.go
+++ b/robotstxt.go
@@ -57,7 +57,7 @@ func (e ParseError) Error() string {
 }
 
 var AllowAll = &RobotsData{allowAll: true}
-var disallowAll = &RobotsData{disallowAll: true}
+var DisallowAll = &RobotsData{disallowAll: true}
 var emptyGroup = &Group{}
 
 func FromStatusAndBytes(statusCode int, body []byte) (*RobotsData, error) {
@@ -78,7 +78,7 @@ func FromStatusAndBytes(statusCode int, body []byte) (*RobotsData, error) {
 	// Server errors (5xx) are seen as temporary errors that result in a "full
 	// disallow" of crawling.
 	case statusCode >= 500 && statusCode < 600:
-		return disallowAll, nil
+		return DisallowAll, nil
 	}
 
 	return nil, errors.New("Unexpected status: " + strconv.Itoa(statusCode))

--- a/robotstxt.go
+++ b/robotstxt.go
@@ -56,7 +56,7 @@ func (e ParseError) Error() string {
 	return b.String()
 }
 
-var allowAll = &RobotsData{allowAll: true}
+var AllowAll = &RobotsData{allowAll: true}
 var disallowAll = &RobotsData{disallowAll: true}
 var emptyGroup = &Group{}
 
@@ -72,7 +72,7 @@ func FromStatusAndBytes(statusCode int, body []byte) (*RobotsData, error) {
 	// This is a "full allow" for crawling. Note: this includes 401
 	// "Unauthorized" and 403 "Forbidden" HTTP result codes.
 	case statusCode >= 400 && statusCode < 500:
-		return allowAll, nil
+		return AllowAll, nil
 
 	// From Google's spec:
 	// Server errors (5xx) are seen as temporary errors that result in a "full
@@ -106,7 +106,7 @@ func FromBytes(body []byte) (r *RobotsData, err error) {
 	// special case (probably not worth optimization?)
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 {
-		return allowAll, nil
+		return AllowAll, nil
 	}
 
 	sc := newByteScanner("bytes", true)
@@ -116,7 +116,7 @@ func FromBytes(body []byte) (r *RobotsData, err error) {
 
 	// special case worth optimization
 	if len(tokens) == 0 {
-		return allowAll, nil
+		return AllowAll, nil
 	}
 
 	r = &RobotsData{}


### PR DESCRIPTION
It may be useful in the following cases:

- **Unit tests.** Let's assume we are testing a function that filters a list of links with a previously parsed `robots.txt` file. How do we check the case when a `robots.txt` file disallows all links? Now it is possible only with actual parsing of the corresponding `robots.txt` file.
- **Errors not related to the network.** Let's assume we are collecting a cache of parsed `robots.txt` files. What should we put in it in case of an error? Yes, the library has the useful functions analyze a status of a response, but not all errors are due to network problems (for example, let the cache accepts links as strings and parses them to construct a link to `robots.txt` files; this parsing may result in an error).
- **Support for temporary ignoring `robots.txt` files.** Let's assume we want to allow a user to ignore `robots.txt` files through a special option. That is, allow all links. Now again, it is possible only with actual parsing of the corresponding `robots.txt` file.

I suppose it would be more comfortable to use the prepared public instances for allowing and disallowing all links.
