### PR TITLE
feat: add Unwrap() []error to ParseError for errors.Is/As support

### DIFF
--- a/robotstxt.go
+++ b/robotstxt.go
@@ -59,6 +59,12 @@ func (e ParseError) Error() string {
 	return b.String()
 }
 
+// Unwrap returns the underlying errors, compatible with errors.Is
+// and errors.As from the standard library (Go 1.20+).
+func (e ParseError) Unwrap() []error {
+	return e.Errs
+}
+
 var allowAll = &RobotsData{allowAll: true}
 var disallowAll = &RobotsData{disallowAll: true}
 var emptyGroup = &Group{}


### PR DESCRIPTION
Fixes #47

## Problem

`ParseError` wraps multiple errors in its `Errs` field but does not implement the `Unwrap() []error` interface (Go 1.20+). This means `errors.Is` and `errors.As` cannot inspect the underlying errors.

## Fix

Add the `Unwrap` method:

```go
func (e ParseError) Unwrap() []error {
    return e.Errs
}
```

## Testing

All existing tests pass.